### PR TITLE
Don't include test dependencies as runtime dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.11.8", "2.12.3")
 libraryDependencies ++= Seq(
   "org.scala-lang" %  "scala-reflect"  % scalaVersion.value,
   "com.typesafe" % "config" % "1.3.1",
-  "org.scalatest" % "scalatest" % "3.0.0" cross CrossVersion.binary
+  "org.scalatest" % "scalatest" % "3.0.0" % Test cross CrossVersion.binary
 )
 
 publishMavenStyle := true


### PR DESCRIPTION
This simple change reduces the jar size from 17 to 5 MB.