### PR TITLE
bug fix: SSConfig#selectDynamic

### DIFF
--- a/src/main/scala/eri/commons/config/SSConfig.scala
+++ b/src/main/scala/eri/commons/config/SSConfig.scala
@@ -82,9 +82,11 @@ class SSConfig(relPath: String = "", relConfig: TConfig = ConfigFactory.load()) 
 
   /** Traversal magic as supported by `scala.Dynamic`. */
   def selectDynamic(name: String) = {
-    val next = if (relPath.nonEmpty && relConfig.hasPath(relPath))
-      relConfig.getConfig(relPath)
-    else relConfig
+    val next = relPath.nonEmpty match {
+      case false => relConfig
+      case true if relConfig.hasPath(relPath + "." + name) => relConfig.getConfig(relPath)
+      case _ => ConfigFactory.empty()
+    }
     new SSConfig(name, next)
   }
 }

--- a/src/test/scala/eri/commons/config/SSConfigTest.scala
+++ b/src/test/scala/eri/commons/config/SSConfigTest.scala
@@ -93,6 +93,12 @@ class SSConfigTest extends FunSpec {
         conf.system.oops.as[String]
       }
     }
+    it("should treat nested name properly") {
+      assert(conf.ints.fortyTwo.asOption[Int] === Some(42))
+      assert(conf.ints.foo.fortyTwo.asOption[Int] === None)
+      assert(conf.akka.actor.typed.timeout.asOption[String] === Some("2s"))
+      assert(conf.akka.actor.typed.timeout.foo.asOption[Int] === None)
+    }
   }
   describe("sequence configuration types") {
     val conf = new SSConfig()


### PR DESCRIPTION
Dear authors, 
I found a following bug and fixed it.

In application.conf, I set `foo.bar = 1`.
Then, I try to get `foo.bar.baz` as Option[Int] (i.e. `conf.foo.bar.baz.asOption[Int]` ).
I expect to get None but actually get Some(1).

See the test cases I added.