### PR TITLE
Added a convenience function for creating Seq readers from a ConfigReader

### DIFF
--- a/src/main/scala/eri/commons/config/ConfigReader.scala
+++ b/src/main/scala/eri/commons/config/ConfigReader.scala
@@ -119,10 +119,19 @@ object ConfigReader {
   }
 
   /** Given a `StringReader[T]`, creates a `ConfigReader[Seq[T]]` */
-  implicit def customConfigSeqReader[T: StringReader]: ConfigReader[Seq[T]] = new ConfigReader[Seq[T]] {
+  implicit def customConfigSeqReaderFromString[T: StringReader]: ConfigReader[Seq[T]] = new ConfigReader[Seq[T]] {
     def apply(path: String, config: Config): Seq[T] = {
       val reader = implicitly[StringReader[T]]
       config.getStringList(path).map(reader.apply)
+    }
+  }
+
+  /** Given a `ConfigReader[T]`, creates a `ConfigReader[Seq[T]]` -
+    * NOTE: This cannot be implicit because it conflicts with customConfigSeqReaderFromString above. */
+  def customConfigSeqReaderFromConfig[T: ConfigReader]: ConfigReader[Seq[T]] = new ConfigReader[Seq[T]] {
+    def apply(path: String, config: Config): Seq[T] = {
+      val reader = implicitly[ConfigReader[T]]
+      config.getObjectList(path).map(obj => reader.apply("", obj.toConfig))
     }
   }
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -100,6 +100,19 @@
     addresses = [ ${extended.addr1}, ${extended.addr3}]
   }
 
+  custom {
+    objects: [
+      {
+        name: "Object 1",
+        location: "Building 1"
+      },
+      {
+        name: "Object 2",
+        location: "Building 2"
+      }
+    ]
+  }
+
   // example support
   akka.actor.typed.timeout = 2s
   akka.version = 2.3.15

--- a/src/test/scala/eri/commons/config/SSConfigTest.scala
+++ b/src/test/scala/eri/commons/config/SSConfigTest.scala
@@ -123,6 +123,20 @@ class SSConfigTest extends FunSpec {
     it("should support config sequence") {
       assert(conf.configs.list.as[Seq[Config]] === Seq(ConfigFactory.parseString("""{"a" : "b"}"""), ConfigFactory.parseString("""{"c" : "d"}""")))
     }
+    it("should support sequences of arbitrary objects") {
+      case class CustomObject(name: String, location: String)
+
+      class CustomObjectReader extends ConfigReader[CustomObject] {
+        override def apply(path: String, config: Config): CustomObject = {
+          val ssConfig = new SSConfig("", config)
+          CustomObject(ssConfig.name.as[String], ssConfig.location.as[String])
+        }
+      }
+
+      implicit val CustomObjectReader: CustomObjectReader = new CustomObjectReader()
+      implicit val CustomObjectSeqReader = ConfigReader.customConfigSeqReaderFromConfig[CustomObject]
+      assert(conf.custom.objects.as[Seq[CustomObject]] === Seq(CustomObject("Object 1", "Building 1"), CustomObject("Object 2", "Building 2")))
+    }
 
   }
   describe("miscellaneous features") {


### PR DESCRIPTION
I tried a few different ways to make this work implicitly like the current StringReader version, but I couldn't find a good way to do it without breaking backwards compatibility.